### PR TITLE
Removed virtual package option from persistent deps.

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Alexandre Jardin <info@ajardin.fr>"
 
 # Install Symfony requirements
 RUN \
-    apk add --no-cache --virtual .persistent-deps \
+    apk add --no-cache \
         freetype-dev \
         git \
         icu-libs \


### PR DESCRIPTION
Fixes #3 .
The `apk add` command which should add the `libjpeg-turbo-dev` dependency does not install anything. This is because in the base image `php:7.2-fpm-alpine` the virtual package name `.persistent-deps` was already used and was not removed with `apk del .persistent-deps` (and it shouldn't be).

Here's what `apk add --help` says about `--virtual`

```
-t, --virtual NAME      Instead of adding all the packages to 'world', create a new virtual package with the listed dependencies and add that to 'world'; the actions of the command are reverted by deleting the virtual package
```
I guess this means that any consecutive `apk add` with the same virtual package name will not add any packages because the virtual package is already added to 'world'.